### PR TITLE
[Fix] Use volume mount instead of copy template file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,6 @@ FROM golang:latest
 WORKDIR /app
 
 COPY ./src .
-COPY ./static /static
 
 RUN ls -la
 # Download all dependencies. Dependencies will be cached if the go.mod and go.sum files are not changed

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.8'
 
 services:
-  backend:
+  godbo-be:
     build:
       context: .
       dockerfile: Dockerfile
@@ -11,7 +11,6 @@ services:
     ports:
       - "8080:8080"
     volumes:
-      - ./app:/go/src/app
       - ./static:/static
     networks:
       internal:


### PR DESCRIPTION
As title mentioned, the `godbo-be` docker no longer copy the static template file.
It will use volume mount instead, so we don't need to rebuild image every time if template changed.